### PR TITLE
Dev/sp navigation links apis

### DIFF
--- a/src/types/sharepoint.types.ts
+++ b/src/types/sharepoint.types.ts
@@ -1445,3 +1445,15 @@ export type IRententionLabel = {
     TagRetentionBasedOn: string;
     UnlockedAsDefault: boolean;
 }
+
+export type spNavLinkLocation = "quicklaunch" | "topnavigationbar" | "none";
+
+export interface INavLinkInfo {
+    Id: number;
+    IsDocLib: boolean;
+    IsExternal: boolean;
+    IsVisible: boolean;
+    Title: string;
+    Url: string;
+    Location: spNavLinkLocation;
+}

--- a/src/utils/sharepoint.rest/exports-index.ts
+++ b/src/utils/sharepoint.rest/exports-index.ts
@@ -4,6 +4,7 @@ export * from './date';
 export * from './file.folder';
 export * from './item';
 export * from './list';
+export * from './navigation-links';
 export * from './user-search';
 export * from './user';
 export * from './web';

--- a/src/utils/sharepoint.rest/navigation-links.ts
+++ b/src/utils/sharepoint.rest/navigation-links.ts
@@ -1,0 +1,86 @@
+import { INavLinkInfo, isNullOrEmptyString, isNullOrUndefined, normalizeUrl } from "../_dependencies";
+import { ConsoleLogger } from "../consolelogger";
+import { GetJson } from "../rest";
+import { GetRestBaseUrl, GetSiteUrl } from "./common";
+
+const logger = ConsoleLogger.get("SharePoint.Rest.Navigation-Links");
+
+/** 
+ * Get all navigation links in the top and side navigation of a SharePoint site 
+ * @param siteUrl The URL of the SharePoint site
+ * @returns An array containing all navigation links
+ */
+export async function GetNavigationLinks(siteUrl?: string): Promise<INavLinkInfo[]> {
+    siteUrl = GetSiteUrl(siteUrl);
+    const topNavUrl = `${GetRestBaseUrl(siteUrl)}/web/navigation/topnavigationbar`;
+    const sideNavUrl = `${GetRestBaseUrl(siteUrl)}/web/navigation/quicklaunch`;
+
+    try {
+        const topNavResponse = await GetJson<{ d: { results: INavLinkInfo[] } }>(topNavUrl);
+        const sideNavResponse = await GetJson<{ d: { results: INavLinkInfo[] } }>(sideNavUrl);
+
+        const topNavLinks: INavLinkInfo[] = topNavResponse.d.results.map((link: INavLinkInfo) => ({ ...link, Location: "topnavigationbar" }));
+        const sideNavLinks: INavLinkInfo[] = sideNavResponse.d.results.map((link: INavLinkInfo) => ({ ...link, Location: "quicklaunch" }));
+
+        return [...topNavLinks, ...sideNavLinks];
+    } catch (error) {
+        logger.error(`Error fetching navigation links: ${error.message}`);
+    }
+    return [];
+}
+
+/** 
+ * Add a navigation link to the specified location (top navigation or side navigation) 
+ * @param title The title of the navigation link
+ * @param url The url of the navigation link
+ * @param location The location where the link will be added ('topnavigationbar' or 'quicklaunch'). Default is 'quicklaunch'.
+ * @Logs If the location is invalid or if adding the link fails
+ */
+export async function AddNavigationLink(location: string = 'quicklaunch'): Promise<INavLinkInfo> {
+    try {
+        let siteUrl = GetSiteUrl();
+        let navigationUrl = "";
+        navigationUrl = `${GetRestBaseUrl(siteUrl)}/web/navigation/${location}`;
+        const response = await GetJson<{ d: INavLinkInfo }>(navigationUrl, JSON.stringify({
+            '__metadata': { 'type': 'SP.NavigationNode' },
+            'Title': "CMS365",
+            'Url': `${normalizeUrl(siteUrl, true)}SitePages/cms365.aspx`
+        }), {
+            spWebUrl: siteUrl,
+        });
+
+
+        if (!isNullOrUndefined(response) && !isNullOrUndefined(response.d)) {
+            return response.d;
+        }
+    } catch (error) {
+        logger.error('Error adding link');
+    }
+}
+
+/** 
+ * Delete navigation links by title and URL
+ * @param navLinks An array of navigation links to be deleted
+ * @Logs If the location is invalid or if deleting the links fails
+ */
+export async function DeleteNavigationLinks(navLinks: INavLinkInfo[]): Promise<void> {
+    try {
+        const siteUrl = GetSiteUrl();
+        for (const navLink of navLinks) {
+            const navigationUrl = `${GetRestBaseUrl(siteUrl)}/web/Navigation/GetNodeById(${navLink.Id})`;
+            // Use the same convention to make the DELETE request
+            const response = await GetJson<any>(navigationUrl, null, {
+                method: 'POST',
+                spWebUrl: siteUrl,
+                xHttpMethod: 'DELETE'
+            });
+
+            if (!isNullOrEmptyString(response) && !response.ok) {
+                logger.error('Failed to delete link');
+            }
+        }
+        logger.info('Navigation links deleted successfully');
+    } catch (error) {
+        logger.error('Error deleting links');
+    }
+}


### PR DESCRIPTION
- Add `INavLinkInfo` interface for Sharepoint Navigation Links objects
- Add `spNavLinkLocation` type for parsing link location in `INavLinkInfo` according to each API call results ("quicklaunch" | "topnavigationbar") 
- Add `GetNavigationLinks`, `AddNavigationLink` and `DeleteNavigationLinks` functions to be utilized for getting all Sharepoint navigation links by siteUrl or for current site if siteUrl is not provided, adding or deleting navigation links