### PR TITLE
web info cleanup

### DIFF
--- a/src/utils/sharepoint.rest/common.ts
+++ b/src/utils/sharepoint.rest/common.ts
@@ -49,7 +49,7 @@ export function GetFileSiteUrl(fileUrl: string): string {
  * If you send a guid - it will look for a site with that ID in the current context site collection
  */
 export function GetSiteUrl(siteUrlOrId?: string): string {
-    if (!isNullOrUndefined && isValidGuid(siteUrlOrId)) {
+    if (!isNullOrUndefined(siteUrlOrId) && isValidGuid(siteUrlOrId)) {
         const webInfo = GetWebInfoSync(null, siteUrlOrId);
         return makeServerRelativeUrl(normalizeUrl(webInfo.ServerRelativeUrl, true));
     }

--- a/src/utils/sharepoint.rest/common.ts
+++ b/src/utils/sharepoint.rest/common.ts
@@ -7,7 +7,7 @@ import { FieldTypeAsString, IFieldInfoEX, IFieldTaxonomyInfo } from "../../types
 import { ISPRestError } from "../../types/sharepoint.utils.types";
 import { ConsoleLogger } from "../consolelogger";
 import { getCacheItem, setCacheItem } from "../localstoragecache";
-import { mediumLocalCache } from "../rest";
+import { GetJsonSync, longLocalCache, mediumLocalCache } from "../rest";
 import { GetWebIdSync, GetWebInfoSync } from "./web";
 
 const logger = ConsoleLogger.get("sharepoint.rest/common");
@@ -26,15 +26,18 @@ export function hasGlobalContext() {
 export function GetFileSiteUrl(fileUrl: string): string {
     let siteUrl: string;
     let urlParts = fileUrl.split('/');
-    if (urlParts[urlParts.length - 1].indexOf('.') > 0)//file name
-        urlParts.pop();//file name
 
-    let key = "GetSiteUrl|" + urlParts.join("/").toLowerCase();
+    let key = "GetSiteUrl|" + fileUrl.toLowerCase();
     siteUrl = getCacheItem<string>(key);
     if (isNullOrUndefined(siteUrl)) {
-        while (!isValidGuid(GetWebIdSync(urlParts.join('/'))))
+        while (urlParts.length > 0) {
+            const candidateUrl = makeServerRelativeUrl(normalizeUrl(urlParts.join("/"), true))
+            const syncResult = GetJsonSync<{ d: { Id: string; }; }>(`${candidateUrl}_api/web/Id`, null, { ...longLocalCache });
+            if (syncResult.success && isValidGuid(syncResult.result.d.Id)) {
+                break
+            }
             urlParts.pop();
-
+        }
         siteUrl = normalizeUrl(urlParts.join('/'));
         setCacheItem(key, siteUrl, mediumLocalCache.localStorageExpiration);//keep for 15 minutes
     }
@@ -46,8 +49,16 @@ export function GetFileSiteUrl(fileUrl: string): string {
  * If you send a guid - it will look for a site with that ID in the current context site collection
  */
 export function GetSiteUrl(siteUrlOrId?: string): string {
-    let siteUrl: string;
-    if (isNullOrUndefined(siteUrlOrId)) {
+    if (!isNullOrUndefined && isValidGuid(siteUrlOrId)) {
+        const webInfo = GetWebInfoSync(null, siteUrlOrId);
+        return makeServerRelativeUrl(normalizeUrl(webInfo.ServerRelativeUrl, true));
+    }
+    return GetSiteUrlLocally(siteUrlOrId);
+}
+
+/** gets a siteUrl locally (without making requests) (todo although currently GetFileSiteUrl does make requests...) */
+export function GetSiteUrlLocally(siteUrl?: string): string {
+    if (isNullOrUndefined(siteUrl)) {
         if (hasGlobalContext()) {
             siteUrl = _spPageContextInfo.webServerRelativeUrl;
             if (_spPageContextInfo.isAppWeb)//#1300 if in a classic app sub-site
@@ -57,20 +68,13 @@ export function GetSiteUrl(siteUrlOrId?: string): string {
             siteUrl = GetFileSiteUrl(window.location.pathname);
         }
     }
-    else if (isValidGuid(siteUrlOrId)) {
-        //GetWebInfoSync calls GetSiteUrl recursively, but with null should not get in here
-        let webInfo = GetWebInfoSync(null, siteUrlOrId);
-        siteUrl = webInfo.ServerRelativeUrl;
-    }
-    else siteUrl = siteUrlOrId;
-
     //must end with / otherwise root sites will return "" and we will think there is no site url.
     return makeServerRelativeUrl(normalizeUrl(siteUrl, true));
 }
 
 /** gets a site url, returns its REST _api url */
 export function GetRestBaseUrl(siteUrl: string): string {
-    siteUrl = GetSiteUrl(siteUrl);
+    siteUrl = GetSiteUrlLocally(siteUrl);
     return siteUrl + '_api';
 }
 

--- a/src/utils/sharepoint.rest/web.ts
+++ b/src/utils/sharepoint.rest/web.ts
@@ -14,7 +14,7 @@ import { AutoDiscoverTenantInfo } from "../auth/discovery";
 import { ConsoleLogger } from "../consolelogger";
 import { toIsoDateFormat } from "../date";
 import { GetJson, GetJsonSync, extraLongLocalCache, longLocalCache, mediumLocalCache, noLocalCache, shortLocalCache, weeekLongLocalCache } from "../rest";
-import { CONTENT_TYPES_SELECT, CONTENT_TYPES_SELECT_WITH_FIELDS, GetRestBaseUrl, GetSiteUrl, LIST_EXPAND, LIST_SELECT, WEB_SELECT, hasGlobalContext } from "./common";
+import { CONTENT_TYPES_SELECT, CONTENT_TYPES_SELECT_WITH_FIELDS, GetRestBaseUrl, GetSiteUrl, GetSiteUrlLocally, LIST_EXPAND, LIST_SELECT, WEB_SELECT, hasGlobalContext } from "./common";
 import { GetListFields, GetListFieldsSync, GetListRestUrl } from "./list";
 import { SPTimeZoneIdToIANATimeZoneName } from "./timzone-map";
 
@@ -611,7 +611,7 @@ export async function GetWebInfo(siteUrl: string, webId?: string, refreshCache?:
             if (currentWebId !== webId) {
                 let url = _getWebInfoByIdRequestUrl(siteUrl, webId);
                 webInfoResponse = await GetJson<IGetWebInfoResponse>(url, null, {
-                    method: "POST", spWebUrl: GetSiteUrl(siteUrl), ...shortLocalCache,
+                    method: "POST", spWebUrl: GetSiteUrlLocally(siteUrl), ...shortLocalCache,
                     jsonMetadata: jsonTypes.nometadata,
                     allowCache: refreshCache !== true
                 });
@@ -641,7 +641,7 @@ export function GetWebInfoSync(siteUrl: string, webId?: string): IWebBasicInfo {
         if (currentWebId !== webId) {
             let url = _getWebInfoByIdRequestUrl(siteUrl, webId);
             let syncResult = GetJsonSync<IGetWebInfoResponse>(url, null, {
-                method: "POST", spWebUrl: GetSiteUrl(siteUrl), ...shortLocalCache,
+                method: "POST", spWebUrl: GetSiteUrlLocally(siteUrl), ...shortLocalCache,
                 jsonMetadata: jsonTypes.nometadata
             });
             if (syncResult.success) {


### PR DESCRIPTION
## problem
Functions in `src/utils/sharepoint.rest/web.ts` are tightly coupled, lack explicit responsibilities, and call each other circularly which is hard to follow and reason with.

Call stack graph generated with `Code2Flow` (`"module": "es2020"`, `splines="ortho"; deleted`) of the unchanged code:

![before](https://github.com/user-attachments/assets/512fe278-a74e-46e6-aa2e-b216375bdd34)

- Note that `GetJsonSync` can call various other functions in this call graph through `getFormDigest` during `POST` requests. However, since all requests in these functions are `GET` requests, I have omitted this call edge.

## core URL resolution logic <br>(`GetSiteUrl` & `GetFileSiteUrl` & `GetRestBaseUrl`)
- candidate URL is provided via argument
- `hasGlobalContext` -> `_spPageContextInfo.webServerRelativeUrl`
- `window.location.pathname`
- property of WebInfo `.ServerRelativeUrl`

## core WebInfo resolution logic<br>(`GetWebInfo` & `GetWebInfoSync`)
- `GET` request using `/_api/site/openWebById('{ID}')?$Select={...WEB_INFO}`
- `GET` request using `/_api/web?$Select={...WEB_INFO}`

## core WebId resolution logic<br>(`GetWebId` & `GetWebIdSync`)
- `GET` request using `/_api/web/Id`

## proposed changes

There are 2 circular call stacks present. The changes proposed do not (should not?) change ANY exported function behaviour.

1. `GetSiteUrl > GetWebInfoSync > GetSiteUrl`. Here, if `GetSiteUrl` is given a GUID, it intentionally calls `GetWebInfoSync` with `siteUrl = null` to trigger the "local" resolution of getting an initial `siteUrl` to make the `GetWebInfoSync` call with. The proposed solution is to refactor the "local" resolution logic of `GetSiteUrl` into `GetSiteUrlLocally`. This way, `GetSiteUrl` is given a clearer responsibility, and functions that want to resolve a siteUrl locally (possibly using a candidate URL, but NOT using a GUID) can call `GetSiteUrlLocally`.

2. `GetSiteUrl > GetFileSiteUrl > GetWebIdSync > _getWebIdRequestUrl > GetRestBaseUrl > GetSiteUrl`. Here, `GetFileSiteUrl` needs a url to perform its "brute force" check of its current url. It obtains that by traversing the call stack all the way to `GetSiteUrl` which just returns `makeServerRelativeUrl(normalizeUrl(<url>))`. The proposed solution is to keep its logic more contained in its function by simply calling `makeServerRelativeUrl(normalizeUrl(<url>))` directly, thus, not giving the impression that `GetSiteUrl` is performing some sort of circular magic.<br>
Note: There was also an infinite loop bug in `GetFileSiteUrl` that has been fixed, and a bug where the site file name may have been popped that was fixed.

Call stack graph after changes:

![after](https://github.com/user-attachments/assets/c32c7d56-b7f0-4f2d-85f2-d9991e5125d4)
