### PR TITLE
fix DeleteAttachment

### DIFF
--- a/src/utils/sharepoint.rest/item.ts
+++ b/src/utils/sharepoint.rest/item.ts
@@ -251,13 +251,14 @@ export async function DeleteAttachment(siteUrl: string, listIdOrTitle: string, i
 
     let url = GetListRestUrl(siteUrl, listIdOrTitle) + `/items(${itemId})/AttachmentFiles('${encodeURIComponentEX(filename, { singleQuoteMultiplier: 2 })}')`;
 
+    let result: { deleted: boolean; errorMessage?: string; } = { deleted: true };
     try {
-        let result = await GetJson<{ d: IAttachmentInfo; }>(url, null, { includeDigestInGet: true, includeDigestInPost: true, xHttpMethod: "DELETE" });
-        let attachmentFile = result && result.d;
-        return attachmentFile;
+        await GetJson<{ d: IAttachmentInfo; }>(url, null, { spWebUrl: siteUrl, method: "POST", xHttpMethod: "DELETE" });
     } catch (e) {
+        result.deleted = false;
+        result.errorMessage = __getSPRestErrorData(e).message;
     }
-    return null;
+    return result;
 }
 
 //** Update value of taxonomy multi-value field. See issue 7585 for more info */


### PR DESCRIPTION
Issue: since the body is `null`, the request method was defaulting to `GET` and the attachment was not being deleted.

Note that although I have changed the return type, I don't believe this function is currently in use so it should not break anything.