### PR TITLE
misc bugs

### DIFF
--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -783,7 +783,7 @@ export function setSelectOptionByValue(selectElement: HTMLSelectElement, value: 
 }
 
 export function setSelectOptionByIndex(selectElement: HTMLSelectElement, index: number): HTMLOptionElement {
-    if (isNullOrUndefined(selectElement) || isNumeric(index)) {
+    if (isNullOrUndefined(selectElement) || !isNumeric(index)) {
         return null;
     }
 
@@ -1029,7 +1029,7 @@ export function HTMLDecode(a) {
     var e = [/&lt;/g, /&gt;/g, /&quot;/g, /&#39;/g, /&#58;/g, /&#123;/g, /&#125;/g, /&amp;/g];
     var f = ["<", ">", '"', "'", ":", "{", "}", "&"];
     var d: string[] = [];
-    for (var c = 0; c < a.length; c++) {
+    for (var c = 0; c < e.length; c++) {
         var b = a.indexOf("&");
         if (b !== -1) {
             if (b > 0) {

--- a/src/helpers/sharepoint.ts
+++ b/src/helpers/sharepoint.ts
@@ -78,7 +78,7 @@ export function ensureClassicExperience(listId: string) {
         setCookie(MODERN_EXPERIENCE_TEMP_COOKIE_NAME, splnu);
     }
     if (isString(mobile)) {
-        setCookie(MOBILE_EXPERIENCE_TEMP_COOKIE_NAME, splnu);
+        setCookie(MOBILE_EXPERIENCE_TEMP_COOKIE_NAME, mobile);
     }
     setCookie(MOBILE_EXPERIENCE_COOKIE_NAME, "0", null, "/");
     switchToClassicExperience(listId);
@@ -103,7 +103,7 @@ export function switchToModernExperience(reload?: boolean) {
 export function SchemaXmlToJson(xml: string): IFieldJsonSchema {
     let result: IFieldJsonSchema = { Attributes: {}, Customizations: {} };
     try {
-        if (!isNullOrEmptyString(xml !== null)) {
+        if (xml) {
             //IE9+ supports this, we don't need to support IE8 anymore
             let SchemaXmlDoc: Document = new DOMParser().parseFromString(xml, "text/xml");
             let xField = SchemaXmlDoc.getElementsByTagName("Field")[0];
@@ -112,14 +112,12 @@ export function SchemaXmlToJson(xml: string): IFieldJsonSchema {
             }
 
             let properties = xField.querySelectorAll("Customization>ArrayOfProperty>Property");
-            if (properties && properties.length > 0) {
-                properties.forEach(p => {
-                    let name = p.querySelector("Name");
-                    let value = p.querySelector("Value");
-                    if (name && value && !isNullOrEmptyString(name.textContent))
-                        result.Customizations[name.textContent] = value.textContent;
-                });
-            }
+            properties.forEach(p => {
+                let name = p.querySelector("Name");
+                let value = p.querySelector("Value");
+                if (name && value && !isNullOrEmptyString(name.textContent))
+                    result.Customizations[name.textContent] = value.textContent;
+            });
         }
     } catch (e) { }
     return result;

--- a/src/helpers/typecheckers.ts
+++ b/src/helpers/typecheckers.ts
@@ -23,7 +23,7 @@ export function typeofFullName(fullName: string, windowOrParent?: Window | any) 
             obj = obj[names[i]];
             if (typeof obj === _objectTypes.Undefined)
                 return _objectTypes.Undefined;
-            if (obj === null && i < len)//one of the chained objects (not the leaf) is null - so return undefined
+            if (obj === null && i < len - 1)//one of the chained objects (not the leaf) is null - so return undefined
                 return _objectTypes.Undefined;
         }
         return typeof obj;


### PR DESCRIPTION
fixes for the following misc bugs

file | code | issue
-- | -- | --
[common/src/helpers/sharepoint.ts](https://github.com/SnapOn-Software/common/blob/3c8956d3f7ce21d38ba7e72ad94acaca1347d5fc/src/helpers/sharepoint.ts#L102) | if (!isNullOrEmptyString(xml !== null)) { | branch always truthy, change to if (xml)
[common/src/helpers/sharepoint.ts](https://github.com/skrukwa/common/blob/35cad9bf5aada112acb5f8ef14e63df84eb33302/src/helpers/sharepoint.ts#L111) | if (properties && properties.length > 0) { | properties always truthy and length check unnecessary
[common/src/helpers/sharepoint.ts](https://github.com/skrukwa/common/blob/35cad9bf5aada112acb5f8ef14e63df84eb33302/src/helpers/sharepoint.ts#L77) | setCookie(MOBILE_EXPERIENCE_TEMP_COOKIE_NAME, splnu); | splnu should be mobile (copy paste error)
[common/src/helpers/typecheckers.ts](https://github.com/skrukwa/common/blob/35cad9bf5aada112acb5f8ef14e63df84eb33302/src/helpers/typecheckers.ts#L26) | if (obj === null && i < len) | i < len always truthy (off by 1 error?)
[common/src/helpers/browser.ts](https://github.com/skrukwa/common/blob/35cad9bf5aada112acb5f8ef14e63df84eb33302/src/helpers/browser.ts#L786) | if (isNullOrUndefined(selectElement) \|\| isNumeric(index)) { | should be !isNumeric (should we just delete this func?)
[common/src/helpers/browser.ts](https://github.com/skrukwa/common/blob/35cad9bf5aada112acb5f8ef14e63df84eb33302/src/helpers/browser.ts#L1032) | for (var c = 0; c < a.length; c++) { | a.length should be e.length (may still be incorrect - delete?)
